### PR TITLE
Update svn-current/trunk/src/burn/drv/sega/d_sys18.cpp

### DIFF
--- a/svn-current/trunk/src/burn/drv/sega/d_sys18.cpp
+++ b/svn-current/trunk/src/burn/drv/sega/d_sys18.cpp
@@ -2333,9 +2333,9 @@ static INT32 LghostInit()
 
 static INT32 MwalkblPatchRom()
 {
-	*((UINT16*)(System16Rom + 0x070212)) = 0x4e71;
-	*((UINT16*)(System16Rom + 0x070116)) = 0x4e71;
-	*((UINT16*)(System16Rom + 0x00314a)) = 0x4642;
+	*((UINT16*)(System16Rom + 0x070212)) = BURN_ENDIAN_SWAP_INT16(0x4e71);
+	*((UINT16*)(System16Rom + 0x070116)) = BURN_ENDIAN_SWAP_INT16(0x4e71);
+	*((UINT16*)(System16Rom + 0x00314a)) = BURN_ENDIAN_SWAP_INT16(0x4642);
 	System16Rom[0x00311a] = 0x3f;
 	System16Rom[0x070103] = 0x00;
 	System16Rom[0x070109] = 0x00;


### PR DESCRIPTION
Patching MwalkblPatchRom to make Moonwalker Bootleg runnable on X360 and PS3
