### PR TITLE
Don't do ordered compares against pointers

### DIFF
--- a/svn-current/trunk/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/svn-current/trunk/src/burn/drv/neogeo/d_neogeo.cpp
@@ -1192,7 +1192,7 @@ static pSekWriteWordHandler pSMABankswitchHandler[MAX_SLOT] = { NULL, };
 void NeoSMABankswitch()
 {
 	SekMapMemory(Neo68KROMActive + nNeo68KROMBank, 0x200000, 0x2FE3FF, SM_ROM);
-	if (nNeoSMARNGAddress[0] > 0 || nNeoSMARNGAddress[1] > 0) {
+	if (nNeoSMARNGAddress[0] != NULL || nNeoSMARNGAddress[1] != NULL) {
 		SekMapMemory(Neo68KROMActive + nNeo68KROMBank + 0x0FE800, 0x2FE800, 0x2FFBFF, SM_ROM);
 	} else {
 		SekMapMemory(Neo68KROMActive + nNeo68KROMBank + 0x0FE800, 0x2FE800, 0x2FFFFF, SM_ROM);

--- a/svn-current/trunk/src/burn/drv/taito/d_taitomisc.cpp
+++ b/svn-current/trunk/src/burn/drv/taito/d_taitomisc.cpp
@@ -5729,7 +5729,7 @@ static INT32 TopspeedFrame()
 		nNext = (i + 1) * nTaitoCyclesTotal[nCurrentCPU] / nInterleave;
 		nTaitoCyclesSegment = nNext - nTaitoCyclesDone[nCurrentCPU];
 		nTaitoCyclesDone[nCurrentCPU] += SekRun(nTaitoCyclesSegment);
-		if (i == (nInterleave / 2) && (GetCurrentFrame > 0)) SekSetIRQLine(6, SEK_IRQSTATUS_AUTO);
+		if (i == (nInterleave / 2) && (GetCurrentFrame != NULL)) SekSetIRQLine(6, SEK_IRQSTATUS_AUTO);
 		if (i == (nInterleave - 1)) SekSetIRQLine(TaitoIrqLine, SEK_IRQSTATUS_AUTO);
 		SekClose();
 		
@@ -5740,7 +5740,7 @@ static INT32 TopspeedFrame()
 			nNext = (i + 1) * nTaitoCyclesTotal[nCurrentCPU] / nInterleave;
 			nTaitoCyclesSegment = nNext - nTaitoCyclesDone[nCurrentCPU];
 			nTaitoCyclesDone[nCurrentCPU] += SekRun(nTaitoCyclesSegment);
-			if (i == (nInterleave / 2) && (GetCurrentFrame > 0)) SekSetIRQLine(6, SEK_IRQSTATUS_AUTO);
+			if (i == (nInterleave / 2) && (GetCurrentFrame != NULL)) SekSetIRQLine(6, SEK_IRQSTATUS_AUTO);
 			if (i == (nInterleave - 1)) SekSetIRQLine(TaitoIrqLine, SEK_IRQSTATUS_AUTO);
 			SekClose();
 		}


### PR DESCRIPTION
When compiled for Android against ndk 15, the compiler complains that pointers cannot be ordered compared to. This switches > 0 checks to NULL comparisons.