### PR TITLE
Add 5 NeoGeo ROM drivers from FBA 0.2.97.42.

### DIFF
--- a/svn-current/trunk/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/svn-current/trunk/src/burn/drv/neogeo/d_neogeo.cpp
@@ -3824,6 +3824,361 @@ struct BurnDriver BurnDrvSsideki3 = {
 	0x1000, 320, 224, 4, 3
 };
 
+// The King of Fighters '95 (Special 2017)
+  // Modified by: GSC2007	
+  // Version number: Ver 1.0.0627 
+
+  static struct BurnRomInfo kof95spRomDesc[] = {
+  	{ "084-p1sp.p1",  0x100000, 0x8bcca012, 1 | BRF_ESS | BRF_PRG }, //  0 68K code			
+  	{ "084-p2sp.p2",  0x100000, 0x5cb1af9e, 1 | BRF_ESS | BRF_PRG }, //  1			
+  	{ "084-p3sp.p3",  0x020000, 0x030e71cb, 1 | BRF_ESS | BRF_PRG }, //  2			
+
+  	{ "084-s1sp.s1",  0x020000, 0x83cbae60, 2 | BRF_GRA },           //  3 Text layer tiles / TC531000
+
+  	{ "084-c1.c1",    0x400000, 0xfe087e32, 3 | BRF_GRA },           //  4 Sprite data		/ TC5332202
+  	{ "084-c2.c2",    0x400000, 0x07864e09, 3 | BRF_GRA },           //  5 					/ TC5332202
+  	{ "084-c3.c3",    0x400000, 0xa4e65d1b, 3 | BRF_GRA },           //  6					/ TC5332202
+  	{ "084-c4.c4",    0x400000, 0xc1ace468, 3 | BRF_GRA },           //  7 					/ TC5332202
+  	{ "084-c5.c5",    0x200000, 0x8a2c1edc, 3 | BRF_GRA },           //  8 					/ TC5316200
+  	{ "084-c6.c6",    0x200000, 0xf593ac35, 3 | BRF_GRA },           //  9 					/ TC5316200
+  	{ "084-c7.c7",    0x100000, 0x9904025f, 3 | BRF_GRA },           // 10 					/ TC538200
+  	{ "084-c8.c8",    0x100000, 0x78eb0f9b, 3 | BRF_GRA },           // 11 					/ TC538200
+
+  	{ "084-m1.m1",    0x020000, 0x6f2d7429, 4 | BRF_ESS | BRF_PRG }, // 12 Z80 code			/ TC531001
+
+  	{ "084-v1.v1",    0x400000, 0x84861b56, 5 | BRF_SND },           // 13 Sound data		/ TC5332201
+  	{ "084-v2.v2",    0x200000, 0xb38a2803, 5 | BRF_SND },           // 14 					/ TC5316200
+  	{ "084-v3.v3",    0x100000, 0xd683a338, 5 | BRF_SND },           // 15 					/ TC538200
+  };
+
+  STDROMPICKEXT(kof95sp, kof95sp, neogeo)
+  STD_ROM_FN(kof95sp)
+
+  static UINT8 *kof95spExtraROM;
+
+  static INT32 Kof95spInit()
+  {
+   	INT32 nRet = NeoInit();
+
+  	if (nRet == 0) {
+          	kof95spExtraROM = (UINT8*)BurnMalloc(0x20000);
+
+  		if (BurnLoadRom(kof95spExtraROM, 2, 1)) return 1;
+
+  		UINT16 *rom = (UINT16*)kof95spExtraROM;
+  		for (INT32 i = 0; i < 0x20000/2; i++) {
+  			if (rom[i] == 0x4e7d) rom[i] = 0x4e71;
+  			if (rom[i] == 0x4e7c) rom[i] = 0x4e75;
+  		}
+
+  		rom = (UINT16*)Neo68KROMActive;
+
+  		for (INT32 i = 0; i < 0x100000/2; i++) {
+  			if (rom[i] == 0x4e7d) rom[i] = 0x4e71;
+  			if (rom[i] == 0x4e7c) rom[i] = 0x4e75;
+  		}
+
+  		rom[0x1f3a8] = 0x2b7c; // 4ef9
+  		rom[0x1f3a9] = 0x0003; // 0090
+  		rom[0x1f3aa] = 0xe7fa; // 16be
+
+          	SekOpen(0);
+          	SekMapMemory(kof95spExtraROM, 0x900000, 0x91ffff, SM_ROM);
+          	SekClose();
+  	}
+
+  	return nRet;
+  }
+
+  static INT32 Kof95spExit()
+  {
+      BurnFree (kof95spExtraROM);
+
+      return NeoExit();
+  }
+
+  struct BurnDriver BurnDrvKof95sp = {
+  	"kof95sp", "kof95", "neogeo", NULL, "2017",
+  	"The King of Fighters '95 (Special 2017, hack)\0", NULL, "hack", "Neo Geo MVS",
+  	NULL, NULL, NULL, NULL,
+  	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+  	NULL, kof95spRomInfo, kof95spRomName, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+  	Kof95spInit, Kof95spExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+  	0x1000, 304, 224, 4, 3
+  };
+// The Last Blade / Bakumatsu Roman - Gekka no Kenshi (Special 2017, hack)
+  // Modified by: GSC2007	
+  // Version number: Ver 1.0.0701 
+
+  static struct BurnRomInfo lastbladspRomDesc[] = {
+  	{ "234-p1sp.p1",  0x100000, 0xb902e73e, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+  	{ "234-p2sp.sp2", 0x600000, 0x8ff3fb6d, 1 | BRF_ESS | BRF_PRG }, //  1 
+  	{ "234-p3sp.sp2", 0x020000, 0xfbd011f7, 0 | BRF_ESS | BRF_PRG }, //  1 
+
+  	{ "234-s1.s1",    0x020000, 0x95561412, 2 | BRF_GRA },           //  2 Text layer tiles
+
+  	{ "234-c1.c1",    0x800000, 0x9f7e2bd3, 3 | BRF_GRA },           //  3 Sprite data
+  	{ "234-c2.c2",    0x800000, 0x80623d3c, 3 | BRF_GRA },           //  4 
+  	{ "234-c3.c3",    0x800000, 0x91ab1a30, 3 | BRF_GRA },           //  5 
+  	{ "234-c4.c4",    0x800000, 0x3d60b037, 3 | BRF_GRA },           //  6 
+  	{ "234-c5sp.c5",  0x400000, 0x4ea22fe0, 3 | BRF_GRA },           //  7 
+  	{ "234-c6sp.c6",  0x400000, 0xa863c882, 3 | BRF_GRA },           //  8 
+
+  	{ "234-m1.m1",    0x020000, 0x087628ea, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
+
+  	{ "234-v1.v1",    0x400000, 0xed66b76f, 5 | BRF_SND },           // 10 Sound data
+  	{ "234-v2.v2",    0x400000, 0xa0e7f6e2, 5 | BRF_SND },           // 11 
+  	{ "234-v3.v3",    0x400000, 0xa506e1e2, 5 | BRF_SND },           // 12 
+  	{ "234-v4.v4",    0x400000, 0x0e34157f, 5 | BRF_SND },           // 13 
+  };
+
+  STDROMPICKEXT(lastbladsp, lastbladsp, neogeo)
+  STD_ROM_FN(lastbladsp)
+
+  static UINT8 *lastbladspExtraROM;
+
+  static INT32 LastbladspInit()
+  {
+   	INT32 nRet = NeoInit();
+
+  	if (nRet == 0) {
+          	lastbladspExtraROM = (UINT8*)BurnMalloc(0x20000);
+
+  		if (BurnLoadRom(lastbladspExtraROM, 2, 1)) return 1;
+
+  		UINT16 *rom = (UINT16*)lastbladspExtraROM;
+  		for (INT32 i = 0; i < 0x20000/2; i++) {
+  			if (rom[i] == 0x4e7d) rom[i] = 0x4e71;
+  			if (rom[i] == 0x4e7c) rom[i] = 0x4e75;
+  		}
+
+  		rom = (UINT16*)Neo68KROMActive;
+
+  		for (INT32 i = 0; i < 0x100000/2; i++) {
+  			if (rom[i] == 0x4e7d) rom[i] = 0x4e71;
+  			if (rom[i] == 0x4e7c) rom[i] = 0x4e75;
+  		}
+
+  		rom[0x69c10/2] = 0x303c; // 4ef9
+  		rom[0x69c12/2] = 0x0b37; // 0091
+  		rom[0x69c14/2] = 0x323c; // 03c4
+  		rom[0x69c16/2] = 0x0013; // 4e7d
+
+          	SekOpen(0);
+          	SekMapMemory(lastbladspExtraROM, 0x900000, 0x91ffff, SM_ROM);
+          	SekClose();
+  	}
+
+  	return nRet;
+  }
+
+  static INT32 LastbladspExit()
+  {
+      BurnFree (lastbladspExtraROM);
+
+      return NeoExit();
+  }
+  struct BurnDriver BurnDrvlastbladsp = {
+  	"lastbladsp", "lastblad", "neogeo", NULL, "2017",
+  	"The Last Soldier (Special 2017, hack)\0", NULL, "SNK", "Neo Geo MVS",
+  	NULL, NULL, NULL, NULL,
+  	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, 0,
+  	NULL, lastbladspRomInfo, lastbladspRomName, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+  	LastbladspInit, LastbladspExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+  	0x1000, 320, 224, 4, 3
+  };
+
+  // Samurai Shodown II / Shin Samurai Spirits - Haohmaru jigokuhen (Special 2017, hack)
+  // Modified by: GSC2007	
+  // Version number: Ver 1.0.0320
+
+  static struct BurnRomInfo samsho2spRomDesc[] = {
+  	{ "063-p1sp.p1",  0x100000, 0x19260a9a, 1 | BRF_ESS | BRF_PRG }, //  0 68k code 
+  	{ "063-p2sp.p2",  0x100000, 0x6e1aef70, 1 | BRF_ESS | BRF_PRG }, //  1 
+  	{ "063-p3sp.p3",  0x020000, 0x8fabd043, 0 | BRF_ESS | BRF_PRG }, //  2
+  		
+  	{ "063-s1sp.s1",  0x020000, 0x1951a907, 2 | BRF_GRA },           //  3 Text layer tiles / TC531000
+
+  	{ "063-c1.c1",    0x200000, 0x86cd307c, 3 | BRF_GRA },           //  4 Sprite data		/ TC5316200
+  	{ "063-c2.c2",    0x200000, 0xcdfcc4ca, 3 | BRF_GRA },           //  5 					/ TC5316200
+  	{ "063-c3.c3",    0x200000, 0x7a63ccc7, 3 | BRF_GRA },           //  6 					/ TC5316200
+  	{ "063-c4.c4",    0x200000, 0x751025ce, 3 | BRF_GRA },           //  7 					/ TC5316200
+  	{ "063-c5.c5",    0x200000, 0x20d3a475, 3 | BRF_GRA },           //  8 					/ TC5316200
+  	{ "063-c6.c6",    0x200000, 0xae4c0a88, 3 | BRF_GRA },           //  9 					/ TC5316200
+  	{ "063-c7sp.c7",  0x200000, 0xdbebced2, 3 | BRF_GRA },           // 10 					/ TC5316200
+  	{ "063-c8sp.c8",  0x200000, 0xbf70b93c, 3 | BRF_GRA },           // 11 					/ TC5316200
+
+  	{ "063-m1.m1",    0x020000, 0x56675098, 4 | BRF_ESS | BRF_PRG }, // 12 Z80 code			/ TC531001
+
+  	{ "063-v1.v1",    0x200000, 0x37703f91, 5 | BRF_SND },           // 13 Sound data		/ TC5316200
+  	{ "063-v2.v2",    0x200000, 0x0142bde8, 5 | BRF_SND },           // 14 					/ TC5316200
+  	{ "063-v3.v3",    0x200000, 0xd07fa5ca, 5 | BRF_SND },           // 15 					/ TC5316200	
+  	{ "063-v4.v4",    0x100000, 0x24aab4bb, 5 | BRF_SND },           // 16 					/ TC538200
+  };
+
+  STDROMPICKEXT(samsho2sp, samsho2sp, neogeo)
+  STD_ROM_FN(samsho2sp)
+
+  static UINT8 *samsho2spExtraROM;
+
+  static INT32 Samsho2spInit()
+  {
+      INT32 nRet = NeoInit();
+
+      if (nRet == 0) {
+          samsho2spExtraROM = (UINT8*)BurnMalloc(0x20000);
+
+          if (BurnLoadRom(samsho2spExtraROM, 2, 1)) return 1;
+
+      //    BurnByteswap(samsho2spExtraROM, 0x20000); // necessary?
+
+          SekOpen(0);
+          SekMapMemory(samsho2spExtraROM, 0x900000, 0x91ffff, SM_ROM);
+          SekClose();
+      }
+
+      return nRet;
+  }
+
+  static INT32 Samsho2spExit()
+  {
+      BurnFree (samsho2spExtraROM);
+
+      return NeoExit();
+  }
+
+  struct BurnDriver BurnDrvSamsho2sp = {
+  	"samsho2sp", "samsho2", "neogeo", NULL, "2017",
+  	"Samurai Shodown II / Shin Samurai Spirits - Haohmaru jigokuhen (Special 2017, hack)\0", NULL, "hack", "Neo Geo MVS",
+  	L"Samurai Shodown II\0\u771F Samurai Spirits - \u8987\u738B\u4E38\u5730\u7344\u5909 (Special 2017, hack)\0", NULL, NULL, NULL,
+  	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_SAMSHO,
+  	NULL, samsho2spRomInfo, samsho2spRomName, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+  	Samsho2spInit, Samsho2spExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+  	0x1000, 320, 224, 4, 3
+  };
+
+  // Samurai Shodown IV - Amakusa's Revenge / Samurai Spirits - Amakusa Kourin (Special 2017, hack)
+  // Modified by: GSC2007 
+  // Version number: Ver 1.0.0501
+
+  static struct BurnRomInfo samsho4spRomDesc[] = {
+  	{ "222-p1sp.p1",  0x100000, 0x6e98579a, 1 | BRF_ESS | BRF_PRG }, //  0 68K code			
+  	{ "222-p2sp.sp2", 0x400000, 0x2c9c64db, 1 | BRF_ESS | BRF_PRG }, //  1 					
+
+  	{ "222-s1.s1",    0x020000, 0x8d3d3bf9, 2 | BRF_GRA },           //  2 Text layer tiles /* TC531000 */
+
+  	{ "222-c1.c1",    0x400000, 0x68f2ed95, 3 | BRF_GRA },           //  3 Sprite data		/* TC5332205 */
+  	{ "222-c2.c2",    0x400000, 0xa6e9aff0, 3 | BRF_GRA },           //  4 					/* TC5332205 */
+  	{ "222-c3.c3",    0x400000, 0xc91b40f4, 3 | BRF_GRA },           //  5 					/* TC5332205 */
+  	{ "222-c4.c4",    0x400000, 0x359510a4, 3 | BRF_GRA },           //  6 					/* TC5332205 */
+  	{ "222-c5.c5",    0x400000, 0x9cfbb22d, 3 | BRF_GRA },           //  7 					/* TC5332205 */
+  	{ "222-c6.c6",    0x400000, 0x685efc32, 3 | BRF_GRA },           //  8 					/* TC5332205 */
+  	{ "222-c7sp.c7",  0x400000, 0xecb13c24, 3 | BRF_GRA },           //  9 					
+  	{ "222-c8sp.c8",  0x400000, 0x0f9a0bda, 3 | BRF_GRA },           // 10 					
+
+  	{ "222-m1.m1",    0x020000, 0x7615bc1b, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code			/* TC531001 */
+
+  	{ "222-v1.v1",    0x400000, 0x7d6ba95f, 5 | BRF_SND },           // 12 Sound data		/* TC5332204 */
+  	{ "222-v2.v2",    0x400000, 0x6c33bb5d, 5 | BRF_SND },           // 13 					/* TC5332204 */
+  	{ "222-v3.v3",    0x200000, 0x831ea8c0, 5 | BRF_SND },           // 14 					/* TC5316200 */
+  };
+
+  STDROMPICKEXT(samsho4sp, samsho4sp, neogeo)
+  STD_ROM_FN(samsho4sp)
+
+  struct BurnDriver BurnDrvSamSho4sp = {
+  	"samsho4sp", "samsho4", "neogeo", NULL, "1996",
+  	"Samurai Shodown IV - Amakusa's Revenge / Samurai Spirits - Amakusa Kourin (Special 2017, hack)\0", NULL, "hack", "Neo Geo MVS",
+  	L"Samurai Shodown IV - Amakusa's Revenge\0\u30B5\u30E0\u30E9\u30A4\u30B9\u30D4\u30EA\u30C3\u30C4 - \u5929\u8349\u964D\u81E8 (Special 2017, hack)\0", NULL, NULL, NULL,
+  	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_SAMSHO,
+  	NULL, samsho4spRomInfo, samsho4spRomName, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+  	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+  	0x1000, 320, 224, 4, 3
+  };
+
+// Double Dragon (Special 2017, hack)
+  // Modified by: GSC2007	
+  // Version number: Ver 1.0.0311
+
+  static struct BurnRomInfo doubledrspRomDesc[] = {
+  	{ "082-p1sp.p1",  0x100000, 0x8ea8ee3d, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+  	{ "082-p2sp.p2",  0x100000, 0x0e2616ab, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+  	{ "082-p3sp.p3",  0x020000, 0x8b4839c4, 1 | BRF_ESS | BRF_PRG }, //  0 68K code	
+
+  	{ "082-s1.s1",    0x020000, 0xbef995c5, 2 | BRF_GRA },           //  1 Text layer tiles / TC531000
+
+  	{ "082-c1.c1",    0x200000, 0xb478c725, 3 | BRF_GRA },           //  2 Sprite data		/ TC5316200
+  	{ "082-c2.c2",    0x200000, 0x2857da32, 3 | BRF_GRA },           //  3 					/ TC5316200
+  	{ "082-c3.c3",    0x200000, 0x8b0d378e, 3 | BRF_GRA },           //  4 					/ TC5316200
+  	{ "082-c4.c4",    0x200000, 0xc7d2f596, 3 | BRF_GRA },           //  5 					/ TC5316200
+  	{ "082-c5sp.c5",  0x200000, 0xb9c799fe, 3 | BRF_GRA },           //  6 					/ TC5316200
+  	{ "082-c6sp.c6",  0x200000, 0x11569bc9, 3 | BRF_GRA },           //  7 					/ TC5316200
+  	{ "082-c7.c7",    0x100000, 0x727c4d02, 3 | BRF_GRA },           //  8 					/ TC538200
+  	{ "082-c8.c8",    0x100000, 0x69a5fa37, 3 | BRF_GRA },           //  9 					/ TC538200
+
+  	{ "082-m1.m1",    0x020000, 0x10b144de, 4 | BRF_ESS | BRF_PRG }, // 10 Z80 code			/ TC531001
+
+  	{ "082-v1.v1",    0x200000, 0xcc1128e4, 5 | BRF_SND },           // 11 Sound data		/ TC5316200
+  	{ "082-v2.v2",    0x200000, 0xc3ff5554, 5 | BRF_SND },           // 12 					/ TC5316200
+  };
+
+  STDROMPICKEXT(doubledrsp, doubledrsp, neogeo)
+  STD_ROM_FN(doubledrsp)
+
+  static UINT8 *doubledrspExtraROM;
+
+  static INT32 DoubledrspInit()
+  {
+   	INT32 nRet = NeoInit();
+
+  	if (nRet == 0) {
+          	doubledrspExtraROM = (UINT8*)BurnMalloc(0x20000);
+
+  		if (BurnLoadRom(doubledrspExtraROM, 2, 1)) return 1;
+
+  		UINT16 *rom = (UINT16*)doubledrspExtraROM;
+  		for (INT32 i = 0; i < 0x20000/2; i++) {
+  			if (rom[i] == 0x4e7d) rom[i] = 0x4e71;
+  			if (rom[i] == 0x4e7c) rom[i] = 0x4e75;
+  		}
+
+  		rom = (UINT16*)Neo68KROMActive;
+
+  		for (INT32 i = 0; i < 0x100000/2; i++) {
+  			if (rom[i] == 0x4e7d) rom[i] = 0x4e71;
+  			if (rom[i] == 0x4e7c) rom[i] = 0x4e75;
+  		}
+
+  		rom[0xbff2] = 0x2b7c; // 4ef9
+  		rom[0xbff3] = 0x0001; // 0091
+  		rom[0xbff4] = 0x7fee; // 0206
+  		rom[0xbff5] = 0xa26a; // 4e7d
+
+          	SekOpen(0);
+          	SekMapMemory(doubledrspExtraROM, 0x900000, 0x91ffff, SM_ROM);
+          	SekClose();
+  	}
+
+  	return nRet;
+  }
+
+  static INT32 DoubledrspExit()
+  {
+      BurnFree (doubledrspExtraROM);
+
+      return NeoExit();
+  }
+
+  struct BurnDriverD BurnDrvdoubledrsp = {
+  	"doubledrsp", "doubledr", "neogeo", NULL, "2017",
+  	"Double Dragon (Special 2017, hack)\0", NULL, "hack", "Neo Geo MVS",
+  	NULL, NULL, NULL, NULL,
+  	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, 0,
+  	NULL, doubledrspRomInfo, doubledrspRomName, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+  	DoubledrspInit, DoubledrspExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+  	0x1000,	320, 224, 4, 3
+  };
+  
 // The King of Fighters '95 (NGM-084)
 
 static struct BurnRomInfo kof95RomDesc[] = {


### PR DESCRIPTION
They are removed in FBA 0.2.97.43, so I think better to keep them in an old FBA build.