### PR TITLE
Remove unimplemented Neo Geo BIOSes

### DIFF
--- a/svn-current/trunk/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/svn-current/trunk/src/burn/drv/neogeo/d_neogeo.cpp
@@ -687,7 +687,7 @@ static struct BurnDIPInfo neogeoDIPList[] = {
 
 	// Fake DIPs
 	// BIOS
-	{0,	0xFD, 0,	28,   "BIOS"                     	         },
+	{0,	0xFD, 0,	30,   "BIOS"                     	         },
 	{0x02,	0x01, 0x1f,	0x00, "MVS Asia/Europe ver. 6 (1 slot)"  },
 	{0x02,	0x01, 0x1f,	0x01, "MVS Asia/Europe ver. 5 (1 slot)"  },
 	{0x02,	0x01, 0x1f,	0x02, "MVS Asia/Europe ver. 3 (4 slot)"  },
@@ -788,7 +788,7 @@ static struct BurnDIPInfo neoFakeDIPList[] = {
 
 	// Fake DIPs
 	// BIOS
-	{0,	0xFD, 0,	28,   "BIOS"                     	         },
+	{0,	0xFD, 0,	30,   "BIOS"                     	         },
 	{0x02,	0x01, 0x1f,	0x00, "MVS Asia/Europe ver. 6 (1 slot)"  },
 	{0x02,	0x01, 0x1f,	0x01, "MVS Asia/Europe ver. 5 (1 slot)"  },
 	{0x02,	0x01, 0x1f,	0x02, "MVS Asia/Europe ver. 3 (4 slot)"  },

--- a/svn-current/trunk/src/burner/libretro/retro_common.cpp
+++ b/svn-current/trunk/src/burner/libretro/retro_common.cpp
@@ -2,48 +2,43 @@
 #include "retro_input.h"
 
 struct RomBiosInfo mvs_bioses[] = {
-	{"sp-s3.sp1",         0x91b64be3, 0x00, "MVS Asia/Europe ver. 6 (1 slot)",  1 },
+	{"asia-s3.rom",       0x91b64be3, 0x00, "MVS Asia/Europe ver. 6 (1 slot)",  1 },
 	{"sp-s2.sp1",         0x9036d879, 0x01, "MVS Asia/Europe ver. 5 (1 slot)",  2 },
 	{"sp-s.sp1",          0xc7f2fa45, 0x02, "MVS Asia/Europe ver. 3 (4 slot)",  3 },
-	{"sp-u2.sp1",         0xe72943de, 0x03, "MVS USA ver. 5 (2 slot)"        ,  4 },
-	{"sp1-u2",            0x62f021f4, 0x04, "MVS USA ver. 5 (4 slot)"        ,  5 },
-	{"sp-e.sp1",          0x2723a5b5, 0x05, "MVS USA ver. 5 (6 slot)"        ,  6 },
-	{"sp1-u4.bin",        0x1179a30f, 0x06, "MVS USA (U4)"                   ,  7 }, 
-	{"sp1-u3.bin",        0x2025b7a2, 0x07, "MVS USA (U3)"                   ,  7 },
-	{"vs-bios.rom",       0xf0e8f27d, 0x08, "MVS Japan ver. 6 (? slot)"      ,  8 },
-	{"sp-j2.sp1",         0xacede59C, 0x09, "MVS Japan ver. 5 (? slot)"      ,  9 },
-	{"sp1.jipan.1024",    0x9fb0abe4, 0x0a, "MVS Japan ver. 3 (4 slot)"      , 10 },
-	{"sp-45.sp1",         0x03cc9f6a, 0x0b, "NEO-MVH MV1C (Asia)"            , 11 },
-	{"sp-j3.sp1",         0x486cb450, 0x0c, "NEO-MVH MV1C (Japan)"           , 12 },
-	{"japan-j3.bin",      0xdff6d41f, 0x0d, "MVS Japan (J3)"                 , 13 },
-	{"sp1-j3.bin",        0xfbc6d469, 0x0e, "MVS Japan (J3, alt)"            , 14 },
-	{"sp-1v1_3db8c.bin",  0x162f0ebe, 0x12, "Deck ver. 6 (Git Ver 1.3)"      , 15 },
+	{"usa_2slt.bin",      0xe72943de, 0x03, "MVS USA ver. 5 (2 slot)"        ,  4 },
+	{"sp-e.sp1",          0x2723a5b5, 0x04, "MVS USA ver. 5 (6 slot)"        ,  5 },
+	{"vs-bios.rom",       0xf0e8f27d, 0x05, "MVS Japan ver. 6 (? slot)"      ,  6 },
+	{"sp-j2.sp1",         0xacede59C, 0x06, "MVS Japan ver. 5 (? slot)"      ,  7 },
+	{"sp1.jipan.1024",    0x9fb0abe4, 0x07, "MVS Japan ver. 3 (4 slot)"      ,  8 },
+	{"sp-45.sp1",         0x03cc9f6a, 0x08, "NEO-MVH MV1C (Asia)"            ,  9 },
+	{"japan-j3.bin",      0xdff6d41f, 0x09, "MVS Japan (J3)"                 , 10 },
+	{"sp-1v1_3db8c.bin",  0x162f0ebe, 0x0d, "Deck ver. 6 (Git Ver 1.3)"      , 11 },
 	{NULL, 0, 0, NULL, 0 }
 };
 
 struct RomBiosInfo aes_bioses[] = {
-	{"neo-po.bin",        0x16d0c132, 0x0f, "AES Japan"                      ,  1 },
-	{"neo-epo.bin",       0xd27a71f1, 0x10, "AES Asia"                       ,  2 },
-	{"neodebug.bin",      0x698ebb7d, 0x11, "Development Kit"                ,  3 },
+	{"neo-po.bin",        0x16d0c132, 0x0a, "AES Japan"                      ,  1 },
+	{"neo-epo.bin",       0xd27a71f1, 0x0b, "AES Asia"                       ,  2 },
+	{"neodebug.bin",      0x698ebb7d, 0x0c, "Development Kit"                ,  3 },
 	{NULL, 0, 0, NULL, 0 }
 };
 
 struct RomBiosInfo uni_bioses[] = {
-	{"uni-bios_4_0.rom",  0xa7aab458, 0x13, "Universe BIOS ver. 4.0"         ,  1 },
-	{"uni-bios_3_3.rom",  0x24858466, 0x14, "Universe BIOS ver. 3.3"         ,  2 },
-	{"uni-bios_3_2.rom",  0xa4e8b9b3, 0x15, "Universe BIOS ver. 3.2"         ,  3 },
-	{"uni-bios_3_1.rom",  0x0c58093f, 0x16, "Universe BIOS ver. 3.1"         ,  4 },
-	{"uni-bios_3_0.rom",  0xa97c89a9, 0x17, "Universe BIOS ver. 3.0"         ,  5 },
-	{"uni-bios_2_3.rom",  0x27664eb5, 0x18, "Universe BIOS ver. 2.3"         ,  6 },
-	{"uni-bios_2_3o.rom", 0x601720ae, 0x19, "Universe BIOS ver. 2.3 (alt)"   ,  7 },
-	{"uni-bios_2_2.rom",  0x2d50996a, 0x1a, "Universe BIOS ver. 2.2"         ,  8 },
-	{"uni-bios_2_1.rom",  0x8dabf76b, 0x1b, "Universe BIOS ver. 2.1"         ,  9 },
-	{"uni-bios_2_0.rom",  0x0c12c2ad, 0x1c, "Universe BIOS ver. 2.0"         , 10 },
-	{"uni-bios_1_3.rom",  0xb24b44a0, 0x1d, "Universe BIOS ver. 1.3"         , 11 },
-	{"uni-bios_1_2.rom",  0x4fa698e9, 0x1e, "Universe BIOS ver. 1.2"         , 12 },
-	{"uni-bios_1_2o.rom", 0xe19d3ce9, 0x1f, "Universe BIOS ver. 1.2 (alt)"   , 13 },
-	{"uni-bios_1_1.rom",  0x5dda0d84, 0x20, "Universe BIOS ver. 1.1"         , 14 },
-	{"uni-bios_1_0.rom",  0x0ce453a0, 0x21, "Universe BIOS ver. 1.0"         , 15 },
+	{"uni-bios_4_0.rom",  0xa7aab458, 0x0e, "Universe BIOS ver. 4.0"         ,  1 },
+	{"uni-bios_3_3.rom",  0x24858466, 0x0f, "Universe BIOS ver. 3.3"         ,  2 },
+	{"uni-bios_3_2.rom",  0xa4e8b9b3, 0x10, "Universe BIOS ver. 3.2"         ,  3 },
+	{"uni-bios_3_1.rom",  0x0c58093f, 0x11, "Universe BIOS ver. 3.1"         ,  4 },
+	{"uni-bios_3_0.rom",  0xa97c89a9, 0x12, "Universe BIOS ver. 3.0"         ,  5 },
+	{"uni-bios_2_3.rom",  0x27664eb5, 0x13, "Universe BIOS ver. 2.3"         ,  6 },
+	{"uni-bios_2_3o.rom", 0x601720ae, 0x14, "Universe BIOS ver. 2.3 (alt)"   ,  7 },
+	{"uni-bios_2_2.rom",  0x2d50996a, 0x15, "Universe BIOS ver. 2.2"         ,  8 },
+	{"uni-bios_2_1.rom",  0x8dabf76b, 0x16, "Universe BIOS ver. 2.1"         ,  9 },
+	{"uni-bios_2_0.rom",  0x0c12c2ad, 0x17, "Universe BIOS ver. 2.0"         , 10 },
+	{"uni-bios_1_3.rom",  0xb24b44a0, 0x18, "Universe BIOS ver. 1.3"         , 11 },
+	{"uni-bios_1_2.rom",  0x4fa698e9, 0x19, "Universe BIOS ver. 1.2"         , 12 },
+	{"uni-bios_1_2o.rom", 0xe19d3ce9, 0x1a, "Universe BIOS ver. 1.2 (alt)"   , 13 },
+	{"uni-bios_1_1.rom",  0x5dda0d84, 0x1b, "Universe BIOS ver. 1.1"         , 14 },
+	{"uni-bios_1_0.rom",  0x0ce453a0, 0x1c, "Universe BIOS ver. 1.0"         , 15 },
 	{NULL, 0, 0, NULL, 0 }
 };
 


### PR DESCRIPTION
Figured out what was causing #101; it looks like at some point somebody tried to add support for Neo Geo BIOS revisions that weren't dumped this far back in FB Alpha history. Nothing very exciting, just things like the 4-slot USA variant, etc. These BIOSes aren't included in FB Alpha's Neo Geo driver this far back, so they were creating a mismatch where the RetroArch frontend had more BIOSes to choose from than the driver actually supported, so that (e.g.) selecting UniBIOS 4.0 (which `libretro.cpp` considered to be `0x13`) would in fact run using UniBIOS 2.3 (which `d_neogeo.cpp`, the Neo Geo driver, considered to be `0x13`).

There's really two ways this could have been fixed: adding all the more recently dumped BIOS revisions from newer FB Alpha/Neo into the Neo Geo Driver, or removing them from the libretro side. I went with the latter option because it was easier and brings the code back in-line with what fbalpha2012_neogeo does (supporting only the BIOSes that FB Alpha did in 2012-or-whereabouts, plus the extra UniBIOSes). As "new" BIOSes go, only the UniBIOSes are particularly interesting, adding cheat codes and other new features. I don't think it's worth adding any of the others to this core or the standalone Neo Geo core.