### PR TITLE
Remove code from cps3run.cpp

### DIFF
--- a/svn-current/trunk/src/burn/drv/cps3/cps3run.cpp
+++ b/svn-current/trunk/src/burn/drv/cps3/cps3run.cpp
@@ -1050,18 +1050,12 @@ static INT32 Cps3Reset()
 		}
 	}
 	
-	// Patch the EEPROM is not needed for sfiii2 and cause some issues if it's done on it.
-	// Normally this is only needed for sfiii but I have nothing to know what the current game is
-	// without adding a new property in the driver
-	if (!cps3_isSpecial)
-	{
-		if (cps3_dip & 0x80) {
-			EEPROM[0x11] = 0x100 + (EEPROM[0x11] & 0xff);
-			EEPROM[0x29] = 0x100 + (EEPROM[0x29] & 0xff);
-		} else {
-			EEPROM[0x11] = 0x000 + (EEPROM[0x11] & 0xff);
-			EEPROM[0x29] = 0x000 + (EEPROM[0x29] & 0xff);
-		}
+	if (cps3_dip & 0x80) {
+		EEPROM[0x11] = 0x100 + (EEPROM[0x11] & 0xff);
+		EEPROM[0x29] = 0x100 + (EEPROM[0x29] & 0xff);
+	} else {
+		EEPROM[0x11] = 0x000 + (EEPROM[0x11] & 0xff);
+		EEPROM[0x29] = 0x000 + (EEPROM[0x29] & 0xff);
 	}
 
 	cps3_current_eeprom_read = 0;	


### PR DESCRIPTION
As said on issue #103, at Android, the core crash when running SFIII (sfiii.zip, sfiiin,zip, etc.), but the core fbalpha2012_cps3 run the ROM perfectly.

The biggest difference between them is that part of the excluded code, which does not exist in the file cps3run.cpp of fbalpha2012_cps3 which runs perfectly.

All other differences involve code to use the fbalpha2012_cps3 core on the Wii.

I have not tested the change, but considering that the comment in the code involves the ROM that is causing the problem, I believe that the problem is there.